### PR TITLE
Allow for overriding the locale used with the createdb command

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,4 @@
 #
 
 default['postgis']['template_name'] = 'template_postgis'
+default['postgis']['locale'] = 'en_US.utf8'

--- a/recipes/_init_database_template.rb
+++ b/recipes/_init_database_template.rb
@@ -2,7 +2,7 @@ execute 'create_postgis_template' do
   not_if "psql -qAt --list | grep -q '^#{node['postgis']['template_name']}\|'", :user => 'postgres'
   user 'postgres'
   command <<CMD
-(createdb -E UTF8 #{node['postgis']['template_name']} -T template0) &&
+(createdb -E UTF8 --locale=#{node['postgis']['locale']} #{node['postgis']['template_name']} -T template0) &&
 (psql -d #{node['postgis']['template_name']} -f `pg_config --sharedir`/contrib/postgis-2.0/postgis.sql) &&
 (psql -d #{node['postgis']['template_name']} -f `pg_config --sharedir`/contrib/postgis-2.0/spatial_ref_sys.sql)
 CMD


### PR DESCRIPTION
Included recipe in Vagrant script and getting this error:

```
createdb: database creation failed: ERROR:  encoding UTF8 does not match locale en_US
DETAIL:  The chosen LC_CTYPE setting requires encoding LATIN1.
```

The solution (for me) was to allow for specifying the locale in the call to createdb.

This is a proposed fix for issue #2. 
