### PR TITLE
rhel derivative support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'peter@realityforge.org'
 license          'Apache 2.0'
 description      'Installs/Configures postgis Postgresql extension'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.5'
+version          '0.2.6'
 
 depends 'apt'
 depends 'yum'
@@ -12,4 +12,5 @@ depends 'postgresql'
 
 supports 'ubuntu'
 supports 'fedora'
+supports 'centos'
 supports 'rhel'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ Note: this includes the postgresql::server after installing the postgis binaries
 =end
 
 case node['platform_family']
-when 'fedora', 'rhel'
+when 'fedora', 'rhel', 'centos'
   # Already in the default repositories
   package 'postgis'
   


### PR DESCRIPTION
Just added a package case for rhel and kind. Tested under Fedora and CentOS
